### PR TITLE
Add guided onboarding tour for new accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ public/ffmpeg
 .DS_Store
 
 docs/
+
+artifacts/

--- a/app/components/AccountPanel.module.css
+++ b/app/components/AccountPanel.module.css
@@ -88,6 +88,28 @@
   border-color: #555;
 }
 
+.helpButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  background: none;
+  border: 1px solid #333;
+  color: #ffc44d;
+  font-size: 0.85rem;
+  font-weight: 700;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.helpButton:hover {
+  background-color: rgba(255, 196, 77, 0.12);
+  border-color: rgba(255, 196, 77, 0.45);
+  color: #ffd77a;
+}
+
 .signOutButton {
   display: flex;
   align-items: center;

--- a/app/components/AccountPanel.tsx
+++ b/app/components/AccountPanel.tsx
@@ -34,9 +34,10 @@ type AccountPanelProps = {
   projects: UserProject[]
   activeProjectId: string | null
   onSelectProject: (projectId: string | null) => void
+  onReplayOnboarding?: () => void
 }
 
-export default function AccountPanel({ projects, activeProjectId, onSelectProject }: AccountPanelProps) {
+export default function AccountPanel({ projects, activeProjectId, onSelectProject, onReplayOnboarding }: AccountPanelProps) {
   const [showPaymentModal, setShowPaymentModal] = useState(false)
   const [folderTrail, setFolderTrail] = useState<Array<{ id: string | null; name: string }>>([{ id: null, name: 'Root' }])
   const uploadInputRef = useRef<HTMLInputElement>(null)
@@ -242,6 +243,16 @@ export default function AccountPanel({ projects, activeProjectId, onSelectProjec
                 Pro
               </button>
             )}
+            {onReplayOnboarding ? (
+              <button
+                type="button"
+                className={styles.helpButton}
+                onClick={onReplayOnboarding}
+                title="Replay getting started tour"
+              >
+                ?
+              </button>
+            ) : null}
             <button type="button" className={styles.signOutButton} onClick={handleSignOut} title="Sign Out">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -296,7 +307,12 @@ export default function AccountPanel({ projects, activeProjectId, onSelectProjec
         <div className={styles.mediaSectionHeader}>
           <p className={styles.mediaSectionLabel}>Media</p>
           <div className={styles.mediaActions}>
-            <button type="button" className={styles.mediaActionButton} onClick={() => uploadInputRef.current?.click()}>
+            <button
+              type="button"
+              className={styles.mediaActionButton}
+              data-onboarding="upload"
+              onClick={() => uploadInputRef.current?.click()}
+            >
               Upload
             </button>
             <button type="button" className={styles.mediaActionButton} onClick={() => setNameModal({ type: 'new-folder' })}>

--- a/app/components/MainView.tsx
+++ b/app/components/MainView.tsx
@@ -18,6 +18,8 @@ import {
   useUserProjectPersistence,
 } from '@/app/lib/projectPersistence'
 import { useProjects } from '@/app/hooks/useProjects'
+import { useOnboardingTour } from '@/app/hooks/useOnboardingTour'
+import OnboardingTour from './onboarding/OnboardingTour'
 import styles from './MainView.module.css'
 
 const Timeline = dynamic(() => import('./Timeline'), {
@@ -39,6 +41,7 @@ export default function MainView() {
   const [pitchItemId, setPitchItemId] = useState<string | null>(null)
   const [localPersistReady, setLocalPersistReady] = useState(false)
   const [chatReady, setChatReady] = useState(false)
+  const [forceOnboarding, setForceOnboarding] = useState(false)
   const { user, loading } = useAuth()
   const { projects, activeProjectId, setActiveProjectId, ready: projectsReady } = useProjects(user?.id ?? null)
   const videos = useManifestStore((s) => s.videos)
@@ -91,6 +94,22 @@ export default function MainView() {
   }, [localPersistReady])
 
   useUserProjectPersistence(localPersistReady ? user : null, activeProjectId)
+
+  const showChatPanel = rightPanel === 'chat'
+  const isProjectLoading =
+    !projectsReady || (!!activeProjectId && !localPersistReady) || !chatReady
+
+  const onboarding = useOnboardingTour(user?.id, !isProjectLoading, { force: forceOnboarding })
+
+  const handleReplayOnboarding = useCallback(() => {
+    setForceOnboarding(true)
+    onboarding.restart()
+  }, [onboarding])
+
+  const handleOnboardingComplete = useCallback(() => {
+    setForceOnboarding(false)
+    onboarding.complete()
+  }, [onboarding])
 
   useEffect(() => {
     if (rightPanel === 'chat' || rightPanel === 'effects') return
@@ -185,10 +204,6 @@ export default function MainView() {
     [audios, selectAudio]
   )
 
-  const showChatPanel = rightPanel === 'chat'
-  const isProjectLoading =
-    !projectsReady || (!!activeProjectId && !localPersistReady) || !chatReady
-
   const renderActivePanel = () => {
     if (rightPanel === 'transitions') {
       return (
@@ -229,6 +244,7 @@ export default function MainView() {
             projects={projects}
             activeProjectId={activeProjectId}
             onSelectProject={setActiveProjectId}
+            onReplayOnboarding={handleReplayOnboarding}
           />
         </div>
         <div className={styles.previewContainer}>
@@ -261,6 +277,9 @@ export default function MainView() {
           </div>
         </div>
       )}
+      {onboarding.active && !isProjectLoading ? (
+        <OnboardingTour onComplete={handleOnboardingComplete} onSkip={handleOnboardingComplete} />
+      ) : null}
     </div>
   )
 }

--- a/app/components/PlaybackControls.tsx
+++ b/app/components/PlaybackControls.tsx
@@ -185,6 +185,7 @@ function PlaybackControls({
         </button>
         <button
           className={styles.exportButton}
+          data-onboarding="export"
           onClick={handleExport}
           disabled={isExporting || (videos.filter((v) => v.row === 0).length === 0 && images.filter((img) => img.row === 0).length === 0)}
         >

--- a/app/components/Timeline.tsx
+++ b/app/components/Timeline.tsx
@@ -710,7 +710,7 @@ export default function Timeline({ onOpenTransitions, onOpenAnimations, onOpenFo
           onChange={handleAudioReplaceSelect}
           style={{ display: 'none' }}
         />
-        <div className={styles.timelineWrapper}>
+        <div className={styles.timelineWrapper} data-onboarding="timeline">
           <PlaybackControls
             totalDuration={totalDuration}
             formatTime={formatTime}

--- a/app/components/onboarding/OnboardingTour.module.css
+++ b/app/components/onboarding/OnboardingTour.module.css
@@ -1,0 +1,187 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  pointer-events: none;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  pointer-events: auto;
+  animation: onboardingFadeIn 0.25s ease-out;
+}
+
+.spotlight {
+  position: fixed;
+  border-radius: 10px;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.72);
+  pointer-events: none;
+  transition: top 0.28s ease, left 0.28s ease, width 0.28s ease, height 0.28s ease;
+  z-index: 3001;
+}
+
+.spotlightPulse {
+  position: absolute;
+  inset: -4px;
+  border-radius: 12px;
+  border: 2px solid rgba(255, 196, 77, 0.85);
+  animation: onboardingPulse 1.6s ease-in-out infinite;
+}
+
+.card {
+  position: fixed;
+  width: min(360px, calc(100vw - 32px));
+  background: #141414;
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  padding: 1.25rem 1.35rem 1.1rem;
+  color: #fff;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55);
+  pointer-events: auto;
+  z-index: 3002;
+  animation: onboardingSlideUp 0.28s ease-out;
+}
+
+.cardCenter {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.stepMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.65rem;
+}
+
+.stepLabel {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #ffc44d;
+  font-weight: 700;
+}
+
+.progressDots {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.dotActive {
+  background: #ffc44d;
+}
+
+.title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin-bottom: 0.45rem;
+  line-height: 1.25;
+}
+
+.description {
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0;
+}
+
+.tip {
+  margin-top: 0.85rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 8px;
+  background: rgba(255, 196, 77, 0.1);
+  border: 1px solid rgba(255, 196, 77, 0.22);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 1.1rem;
+}
+
+.skipButton {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 0.82rem;
+  cursor: pointer;
+  padding: 0.35rem 0.2rem;
+}
+
+.skipButton:hover {
+  color: #bbb;
+}
+
+.primaryActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.backButton,
+.nextButton,
+.doneButton {
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.55rem 0.95rem;
+}
+
+.backButton {
+  background: #222;
+  color: #ddd;
+}
+
+.backButton:hover {
+  background: #2a2a2a;
+}
+
+.nextButton,
+.doneButton {
+  background: #ffc44d;
+  color: #111;
+}
+
+.nextButton:hover,
+.doneButton:hover {
+  filter: brightness(1.05);
+}
+
+@keyframes onboardingFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes onboardingSlideUp {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 12px));
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes onboardingPulse {
+  0%, 100% { opacity: 0.55; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.02); }
+}

--- a/app/components/onboarding/OnboardingTour.tsx
+++ b/app/components/onboarding/OnboardingTour.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ONBOARDING_STEPS, type OnboardingStepPlacement } from './onboardingSteps'
+import styles from './OnboardingTour.module.css'
+
+type SpotlightRect = {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+type CardPosition = {
+  top: number
+  left: number
+}
+
+type Props = {
+  onComplete: () => void
+  onSkip?: () => void
+  initialStep?: number
+}
+
+const CARD_MARGIN = 16
+const CARD_WIDTH = 360
+const CARD_HEIGHT_ESTIMATE = 240
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+function getTargetRect(selector?: string): SpotlightRect | null {
+  if (!selector || typeof document === 'undefined') return null
+  const element = document.querySelector(selector)
+  if (!(element instanceof HTMLElement)) return null
+  const rect = element.getBoundingClientRect()
+  if (rect.width <= 0 || rect.height <= 0) return null
+  const padding = 6
+  return {
+    top: rect.top - padding,
+    left: rect.left - padding,
+    width: rect.width + padding * 2,
+    height: rect.height + padding * 2,
+  }
+}
+
+function getCardPosition(
+  placement: OnboardingStepPlacement,
+  spotlight: SpotlightRect | null,
+  viewportWidth: number,
+  viewportHeight: number
+): CardPosition {
+  if (!spotlight || placement === 'center') {
+    return {
+      top: viewportHeight / 2,
+      left: viewportWidth / 2,
+    }
+  }
+
+  const cardWidth = Math.min(CARD_WIDTH, viewportWidth - CARD_MARGIN * 2)
+
+  if (placement === 'right') {
+    const left = clamp(
+      spotlight.left + spotlight.width + CARD_MARGIN,
+      CARD_MARGIN,
+      viewportWidth - cardWidth - CARD_MARGIN
+    )
+    const top = clamp(
+      spotlight.top + spotlight.height / 2,
+      CARD_HEIGHT_ESTIMATE / 2 + CARD_MARGIN,
+      viewportHeight - CARD_HEIGHT_ESTIMATE / 2 - CARD_MARGIN
+    )
+    return { top, left: left + cardWidth / 2 }
+  }
+
+  if (placement === 'left') {
+    const left = clamp(
+      spotlight.left - CARD_MARGIN,
+      cardWidth / 2 + CARD_MARGIN,
+      viewportWidth - CARD_MARGIN
+    )
+    const top = clamp(
+      spotlight.top + spotlight.height / 2,
+      CARD_HEIGHT_ESTIMATE / 2 + CARD_MARGIN,
+      viewportHeight - CARD_HEIGHT_ESTIMATE / 2 - CARD_MARGIN
+    )
+    return { top, left }
+  }
+
+  if (placement === 'bottom') {
+    const top = clamp(
+      spotlight.top + spotlight.height + CARD_MARGIN + CARD_HEIGHT_ESTIMATE / 2,
+      CARD_HEIGHT_ESTIMATE / 2 + CARD_MARGIN,
+      viewportHeight - CARD_HEIGHT_ESTIMATE / 2 - CARD_MARGIN
+    )
+    const left = clamp(
+      spotlight.left + spotlight.width / 2,
+      cardWidth / 2 + CARD_MARGIN,
+      viewportWidth - cardWidth / 2 - CARD_MARGIN
+    )
+    return { top, left }
+  }
+
+  const top = clamp(
+    spotlight.top - CARD_MARGIN - CARD_HEIGHT_ESTIMATE / 2,
+    CARD_HEIGHT_ESTIMATE / 2 + CARD_MARGIN,
+    viewportHeight - CARD_HEIGHT_ESTIMATE / 2 - CARD_MARGIN
+  )
+  const left = clamp(
+    spotlight.left + spotlight.width / 2,
+    cardWidth / 2 + CARD_MARGIN,
+    viewportWidth - cardWidth / 2 - CARD_MARGIN
+  )
+  return { top, left }
+}
+
+export default function OnboardingTour({ onComplete, onSkip, initialStep = 0 }: Props) {
+  const [stepIndex, setStepIndex] = useState(initialStep)
+  const [mounted, setMounted] = useState(false)
+  const [spotlight, setSpotlight] = useState<SpotlightRect | null>(null)
+  const [cardPosition, setCardPosition] = useState<CardPosition>({ top: 0, left: 0 })
+
+  const step = ONBOARDING_STEPS[stepIndex]
+  const isFirstStep = stepIndex === 0
+  const isLastStep = stepIndex === ONBOARDING_STEPS.length - 1
+  const isCentered = !step.target || step.placement === 'center'
+
+  const refreshLayout = useCallback(() => {
+    const viewportWidth = window.innerWidth
+    const viewportHeight = window.innerHeight
+    const nextSpotlight = getTargetRect(step.target)
+    const placement = step.placement ?? 'center'
+    setSpotlight(nextSpotlight)
+    setCardPosition(getCardPosition(placement, nextSpotlight, viewportWidth, viewportHeight))
+  }, [step.placement, step.target])
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useLayoutEffect(() => {
+    refreshLayout()
+  }, [refreshLayout, stepIndex])
+
+  useEffect(() => {
+    const handleResize = () => refreshLayout()
+    window.addEventListener('resize', handleResize)
+    window.addEventListener('scroll', handleResize, true)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('scroll', handleResize, true)
+    }
+  }, [refreshLayout])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onSkip?.()
+        onComplete()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onComplete, onSkip])
+
+  const handleNext = () => {
+    if (isLastStep) {
+      onComplete()
+      return
+    }
+    setStepIndex((current) => Math.min(current + 1, ONBOARDING_STEPS.length - 1))
+  }
+
+  const handleBack = () => {
+    setStepIndex((current) => Math.max(current - 1, 0))
+  }
+
+  const handleSkip = () => {
+    onSkip?.()
+    onComplete()
+  }
+
+  const cardStyle = useMemo(() => {
+    if (isCentered) {
+      return undefined
+    }
+    return {
+      top: `${cardPosition.top}px`,
+      left: `${cardPosition.left}px`,
+      transform: 'translate(-50%, -50%)',
+    }
+  }, [cardPosition.left, cardPosition.top, isCentered])
+
+  if (!mounted || !step) {
+    return null
+  }
+
+  return createPortal(
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
+      {isCentered ? <div className={styles.backdrop} aria-hidden /> : null}
+      {!isCentered && spotlight ? (
+        <div
+          className={styles.spotlight}
+          style={{
+            top: `${spotlight.top}px`,
+            left: `${spotlight.left}px`,
+            width: `${spotlight.width}px`,
+            height: `${spotlight.height}px`,
+          }}
+          aria-hidden
+        >
+          <div className={styles.spotlightPulse} />
+        </div>
+      ) : null}
+
+      <div
+        className={`${styles.card} ${isCentered ? styles.cardCenter : ''}`}
+        style={cardStyle}
+        data-onboarding-step={step.id}
+      >
+        <div className={styles.stepMeta}>
+          <span className={styles.stepLabel}>
+            Step {stepIndex + 1} of {ONBOARDING_STEPS.length}
+          </span>
+          <div className={styles.progressDots} aria-hidden>
+            {ONBOARDING_STEPS.map((entry, index) => (
+              <span
+                key={entry.id}
+                className={`${styles.dot} ${index === stepIndex ? styles.dotActive : ''}`}
+              />
+            ))}
+          </div>
+        </div>
+        <h2 id="onboarding-title" className={styles.title}>
+          {step.title}
+        </h2>
+        <p className={styles.description}>{step.description}</p>
+        {step.tip ? <div className={styles.tip}>{step.tip}</div> : null}
+        <div className={styles.actions}>
+          <button type="button" className={styles.skipButton} onClick={handleSkip}>
+            Skip tour
+          </button>
+          <div className={styles.primaryActions}>
+            {!isFirstStep ? (
+              <button type="button" className={styles.backButton} onClick={handleBack}>
+                Back
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className={isLastStep ? styles.doneButton : styles.nextButton}
+              onClick={handleNext}
+            >
+              {isLastStep ? 'Start editing' : 'Next'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/app/components/onboarding/onboardingSteps.ts
+++ b/app/components/onboarding/onboardingSteps.ts
@@ -1,0 +1,54 @@
+export type OnboardingStepPlacement = 'top' | 'bottom' | 'left' | 'right' | 'center'
+
+export type OnboardingStep = {
+  id: string
+  title: string
+  description: string
+  target?: string
+  placement?: OnboardingStepPlacement
+  tip?: string
+}
+
+export const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    id: 'welcome',
+    title: 'Welcome to Mango Studio',
+    description:
+      'You are in the editor. This quick tour shows how to upload media, arrange clips on the timeline, and export a finished video.',
+    placement: 'center',
+  },
+  {
+    id: 'upload',
+    title: 'Upload your media',
+    description:
+      'Add videos, images, or audio to your library. Everything you upload stays in your account and can be reused across projects.',
+    target: '[data-onboarding="upload"]',
+    placement: 'right',
+    tip: 'You can also drag files straight onto the timeline.',
+  },
+  {
+    id: 'timeline',
+    title: 'Build on the timeline',
+    description:
+      'Drag items from your library onto the timeline, trim clips, and preview your edit in real time. The playhead shows where you are in the video.',
+    target: '[data-onboarding="timeline"]',
+    placement: 'top',
+    tip: 'Press the play button to preview, or use the toolbar upload to add clips at the playhead.',
+  },
+  {
+    id: 'export',
+    title: 'Export your video',
+    description:
+      'When your timeline has at least one video or image clip, click Export to render and download an MP4.',
+    target: '[data-onboarding="export"]',
+    placement: 'top',
+    tip: 'Export runs in your browser — no upload required.',
+  },
+  {
+    id: 'complete',
+    title: 'You are ready to edit',
+    description:
+      'Upload a clip, drop it on the timeline, tweak your edit, then export. You can replay this tour anytime from the help menu in the media panel.',
+    placement: 'center',
+  },
+]

--- a/app/dev/onboarding-preview/OnboardingPreview.module.css
+++ b/app/dev/onboarding-preview/OnboardingPreview.module.css
@@ -1,0 +1,153 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+  background: #0f0f0f;
+  color: #fff;
+  overflow: hidden;
+}
+
+.editorShell {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.leftPanel,
+.chatPanel {
+  width: 25%;
+  min-width: 220px;
+  border-right: 1px solid #222;
+  background: #0d0d0d;
+  display: flex;
+  flex-direction: column;
+}
+
+.chatPanel {
+  border-right: none;
+  border-left: 1px solid #222;
+}
+
+.panelHeader,
+.mediaHeader,
+.chatHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid #222;
+  font-size: 0.85rem;
+}
+
+.email {
+  color: #888;
+}
+
+.badge {
+  border: 1px solid #333;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.72rem;
+  color: #bbb;
+}
+
+.uploadButton,
+.exportButton,
+.toolbarButton,
+.playButton {
+  border: 1px solid #333;
+  background: #1a1a1a;
+  color: #fff;
+  border-radius: 6px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  cursor: default;
+}
+
+.exportButton {
+  background: #ffc44d;
+  color: #111;
+  border-color: #ffc44d;
+  font-weight: 700;
+}
+
+.libraryPlaceholder {
+  padding: 1rem;
+  color: #777;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.hint {
+  margin-top: 0.75rem;
+  color: #999;
+}
+
+.previewPanel {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111;
+}
+
+.previewFrame {
+  width: min(320px, 70%);
+  aspect-ratio: 9 / 16;
+  border: 1px dashed #333;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  font-size: 0.85rem;
+}
+
+.chatBody {
+  padding: 1rem;
+  color: #777;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.timelineSection {
+  border-top: 1px solid #222;
+  background: #141414;
+  min-height: 180px;
+}
+
+.playbackBar {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid #222;
+}
+
+.playButton {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.timecode {
+  color: #888;
+  font-size: 0.78rem;
+  margin-right: auto;
+}
+
+.timelineTracks {
+  padding: 1rem;
+}
+
+.emptyTrack {
+  border: 1px dashed #333;
+  border-radius: 8px;
+  padding: 1.5rem;
+  text-align: center;
+  color: #666;
+  font-size: 0.82rem;
+}

--- a/app/dev/onboarding-preview/page.tsx
+++ b/app/dev/onboarding-preview/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import OnboardingTour from '@/app/components/onboarding/OnboardingTour'
+import styles from './OnboardingPreview.module.css'
+
+export default function OnboardingPreviewPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.editorShell}>
+        <aside className={styles.leftPanel}>
+          <div className={styles.panelHeader}>
+            <span className={styles.email}>demo@mango.studio</span>
+            <span className={styles.badge}>Free</span>
+          </div>
+          <div className={styles.mediaHeader}>
+            <span>Media</span>
+            <button type="button" className={styles.uploadButton} data-onboarding="upload">
+              Upload
+            </button>
+          </div>
+          <div className={styles.libraryPlaceholder}>
+            <p>Your uploaded clips appear here.</p>
+            <p className={styles.hint}>Drag an item onto the timeline below.</p>
+          </div>
+        </aside>
+
+        <main className={styles.previewPanel}>
+          <div className={styles.previewFrame}>
+            <span>Preview</span>
+          </div>
+        </main>
+
+        <aside className={styles.chatPanel}>
+          <div className={styles.chatHeader}>AI Assistant</div>
+          <div className={styles.chatBody}>Ask Mango to help edit your video.</div>
+        </aside>
+      </div>
+
+      <section className={styles.timelineSection} data-onboarding="timeline">
+        <div className={styles.playbackBar}>
+          <button type="button" className={styles.playButton}>
+            ▶
+          </button>
+          <span className={styles.timecode}>0:00 / 0:00</span>
+          <button type="button" className={styles.toolbarButton}>
+            Upload
+          </button>
+          <button type="button" className={styles.exportButton} data-onboarding="export">
+            Export
+          </button>
+        </div>
+        <div className={styles.timelineTracks}>
+          <div className={styles.emptyTrack}>Drop media here to start editing</div>
+        </div>
+      </section>
+
+      <OnboardingTour onComplete={() => undefined} />
+    </div>
+  )
+}

--- a/app/hooks/useOnboardingTour.ts
+++ b/app/hooks/useOnboardingTour.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { hasCompletedOnboarding, markOnboardingComplete } from '@/app/lib/onboardingStorage'
+import { useManifestStore } from '@/app/stores/manifestStore'
+
+type Options = {
+  enabled?: boolean
+  force?: boolean
+}
+
+export function useOnboardingTour(userId: string | null | undefined, ready: boolean, options: Options = {}) {
+  const { enabled = true, force = false } = options
+  const [active, setActive] = useState(false)
+  const videos = useManifestStore((state) => state.videos)
+  const images = useManifestStore((state) => state.images)
+
+  const timelineIsEmpty = useMemo(
+    () => videos.length === 0 && images.length === 0,
+    [videos.length, images.length]
+  )
+
+  useEffect(() => {
+    if (!enabled || !ready) {
+      setActive(false)
+      return
+    }
+
+    if (force) {
+      setActive(true)
+      return
+    }
+
+    if (!userId) {
+      setActive(false)
+      return
+    }
+
+    if (!timelineIsEmpty) {
+      setActive(false)
+      return
+    }
+
+    setActive(!hasCompletedOnboarding(userId))
+  }, [enabled, force, ready, timelineIsEmpty, userId])
+
+  const complete = useCallback(() => {
+    if (userId) {
+      markOnboardingComplete(userId)
+    }
+    setActive(false)
+  }, [userId])
+
+  const restart = useCallback(() => {
+    setActive(true)
+  }, [])
+
+  return {
+    active,
+    complete,
+    restart,
+  }
+}

--- a/app/lib/onboardingStorage.ts
+++ b/app/lib/onboardingStorage.ts
@@ -1,0 +1,32 @@
+export const ONBOARDING_STORAGE_VERSION = 'v1'
+
+export function onboardingStorageKey(userId: string): string {
+  return `mango-onboarding-${ONBOARDING_STORAGE_VERSION}:${userId}`
+}
+
+export function hasCompletedOnboarding(userId: string | null | undefined): boolean {
+  if (!userId || typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(onboardingStorageKey(userId)) === 'done'
+  } catch {
+    return false
+  }
+}
+
+export function markOnboardingComplete(userId: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(onboardingStorageKey(userId), 'done')
+  } catch {
+    // Ignore quota / private mode errors.
+  }
+}
+
+export function resetOnboarding(userId: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(onboardingStorageKey(userId))
+  } catch {
+    // Ignore quota / private mode errors.
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-dom": "^18.3.0",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.5",
+        "playwright": "^1.55.0",
         "typescript": "^5.5.3",
         "vitest": "^4.1.1"
       }
@@ -7318,6 +7319,53 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "build": "npm run test && next build",
     "start": "next start",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "record:onboarding": "node scripts/record-onboarding-demo.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1029.0",
@@ -32,6 +33,7 @@
     "@types/react-dom": "^18.3.0",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
+    "playwright": "^1.55.0",
     "typescript": "^5.5.3",
     "vitest": "^4.1.1"
   }

--- a/scripts/record-onboarding-demo.mjs
+++ b/scripts/record-onboarding-demo.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 import { spawn } from 'node:child_process'
-import { mkdir, readdir, rename } from 'node:fs/promises'
+import { mkdir, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { chromium } from 'playwright'
+
+const ONBOARDING_STEP_IDS = ['welcome', 'upload', 'timeline', 'export', 'complete']
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(__dirname, '..')
@@ -54,9 +56,13 @@ async function convertToMp4(sourcePath, destinationPath) {
   })
 }
 
-async function clickNext(page, delayMs = 1800) {
+async function waitForStep(page, stepId, holdMs) {
+  await page.locator(`[data-onboarding-step="${stepId}"]`).waitFor({ state: 'visible' })
+  await sleep(holdMs)
+}
+
+async function clickNext(page) {
   await page.locator('[data-onboarding-step] button').filter({ hasText: 'Next' }).click()
-  await sleep(delayMs)
 }
 
 async function main() {
@@ -78,16 +84,22 @@ async function main() {
     })
     const page = await context.newPage()
     await page.goto(previewUrl, { waitUntil: 'networkidle' })
-    await sleep(1200)
 
-    await clickNext(page, 2200)
-    await clickNext(page, 2200)
-    await clickNext(page, 2200)
-    await clickNext(page, 2200)
-    await page.locator('[data-onboarding-step] button').filter({ hasText: 'Start editing' }).click()
-    await sleep(1500)
+    for (const stepId of ONBOARDING_STEP_IDS) {
+      const holdMs = stepId === 'complete' ? 4000 : 2500
+      await waitForStep(page, stepId, holdMs)
+      if (stepId !== 'complete') {
+        await clickNext(page)
+      }
+    }
 
+    await page.locator('[data-onboarding-step="complete"] button').filter({ hasText: 'Start editing' }).click()
+    await sleep(2000)
+
+    await page.close()
+    await sleep(500)
     await context.close()
+    await sleep(500)
 
     const files = await readdir(videoDir)
     const webmFile = files.find((file) => file.endsWith('.webm'))

--- a/scripts/record-onboarding-demo.mjs
+++ b/scripts/record-onboarding-demo.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { mkdir, readdir, rename } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, '..')
+const artifactsDir = path.resolve(rootDir, 'artifacts', 'onboarding-demo')
+const videoDir = path.join(artifactsDir, 'raw')
+const outputPath = path.join(artifactsDir, 'onboarding-tour-demo.mp4')
+const previewUrl = process.env.ONBOARDING_PREVIEW_URL ?? 'http://127.0.0.1:3000/dev/onboarding-preview'
+const port = Number(process.env.PORT ?? 3000)
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForServer(url, timeoutMs = 120_000) {
+  const started = Date.now()
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+    } catch {
+      // Server still booting.
+    }
+    await sleep(1000)
+  }
+  throw new Error(`Timed out waiting for ${url}`)
+}
+
+function startDevServer() {
+  return spawn('npm', ['run', 'dev', '--', '--port', String(port), '--hostname', '127.0.0.1'], {
+    cwd: rootDir,
+    stdio: 'ignore',
+    env: { ...process.env, PORT: String(port) },
+  })
+}
+
+async function convertToMp4(sourcePath, destinationPath) {
+  await new Promise((resolve, reject) => {
+    const ffmpeg = spawn(
+      'ffmpeg',
+      ['-y', '-i', sourcePath, '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-preset', 'fast', destinationPath],
+      { stdio: 'inherit' }
+    )
+    ffmpeg.on('exit', (code) => {
+      if (code === 0) resolve(undefined)
+      else reject(new Error(`ffmpeg exited with code ${code}`))
+    })
+  })
+}
+
+async function clickNext(page, delayMs = 1800) {
+  await page.locator('[data-onboarding-step] button').filter({ hasText: 'Next' }).click()
+  await sleep(delayMs)
+}
+
+async function main() {
+  await mkdir(videoDir, { recursive: true })
+
+  const devServer = startDevServer()
+  let browser
+
+  try {
+    await waitForServer(previewUrl)
+
+    browser = await chromium.launch({ headless: true })
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+      recordVideo: {
+        dir: videoDir,
+        size: { width: 1440, height: 900 },
+      },
+    })
+    const page = await context.newPage()
+    await page.goto(previewUrl, { waitUntil: 'networkidle' })
+    await sleep(1200)
+
+    await clickNext(page, 2200)
+    await clickNext(page, 2200)
+    await clickNext(page, 2200)
+    await clickNext(page, 2200)
+    await page.locator('[data-onboarding-step] button').filter({ hasText: 'Start editing' }).click()
+    await sleep(1500)
+
+    await context.close()
+
+    const files = await readdir(videoDir)
+    const webmFile = files.find((file) => file.endsWith('.webm'))
+    if (!webmFile) {
+      throw new Error('Playwright did not produce a video file')
+    }
+
+    const webmPath = path.join(videoDir, webmFile)
+    await convertToMp4(webmPath, outputPath)
+    console.log(`Recorded onboarding demo: ${outputPath}`)
+  } finally {
+    if (browser) {
+      await browser.close().catch(() => undefined)
+    }
+    devServer.kill('SIGTERM')
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/tests/onboardingStorage.test.ts
+++ b/tests/onboardingStorage.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  onboardingStorageKey,
+  ONBOARDING_STORAGE_VERSION,
+  hasCompletedOnboarding,
+  markOnboardingComplete,
+  resetOnboarding,
+} from '@/app/lib/onboardingStorage'
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>()
+  return {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    clear: () => {
+      store.clear()
+    },
+  }
+}
+
+describe('onboardingStorage', () => {
+  const userId = 'user-123'
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'window', {
+      value: { localStorage: createLocalStorageMock() },
+      configurable: true,
+    })
+  })
+
+  it('uses a versioned storage key', () => {
+    expect(onboardingStorageKey(userId)).toBe(`mango-onboarding-${ONBOARDING_STORAGE_VERSION}:${userId}`)
+  })
+
+  it('tracks completion per user', () => {
+    expect(hasCompletedOnboarding(userId)).toBe(false)
+    markOnboardingComplete(userId)
+    expect(hasCompletedOnboarding(userId)).toBe(true)
+  })
+
+  it('can reset onboarding state', () => {
+    markOnboardingComplete(userId)
+    resetOnboarding(userId)
+    expect(hasCompletedOnboarding(userId)).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

New users now get a guided 5-step onboarding tour when they first land in the editor with an empty timeline. The tour walks through the three core workflows:

1. **Upload** — highlights the media library Upload button
2. **Timeline** — explains drag-and-drop and playback on the timeline
3. **Export** — shows where to render and download the finished MP4

The tour uses a spotlight overlay that points at real UI elements, persists completion in `localStorage`, and can be replayed anytime via the **?** help button in the account panel header.

## Demo video

[onboarding-tour-demo.mp4](https://cursor.com/agents/bc-019f5d37-4d3b-7f16-8a83-d3bd075d30ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding-tour-demo.mp4)

## Changes

- `OnboardingTour` component with spotlight + step cards
- `useOnboardingTour` hook — auto-starts for new users with empty projects
- `data-onboarding` targets on Upload, Timeline, and Export buttons
- Replay button in `AccountPanel` header
- Dev preview page at `/dev/onboarding-preview`
- `npm run record:onboarding` script (Playwright + ffmpeg) to capture demo videos
- Unit tests for onboarding storage helpers

## How to test

1. Sign up / log in with a fresh account (or clear `localStorage` key `mango-onboarding-v1:<userId>`)
2. Confirm the tour appears after the project loads
3. Click through all 5 steps (Welcome → Upload → Timeline → Export → Done)
4. Click **?** in the header to replay the tour
5. Visit `/dev/onboarding-preview` to see the tour without auth

## Recording the demo locally

```bash
npm install
npx playwright install chromium
npm run record:onboarding
# Output: artifacts/onboarding-demo/onboarding-tour-demo.mp4
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5d37-4d3b-7f16-8a83-d3bd075d30ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5d37-4d3b-7f16-8a83-d3bd075d30ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

